### PR TITLE
refactor: 실제 데이터 연동

### DIFF
--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/UnivApi.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/UnivApi.kt
@@ -2,12 +2,13 @@ package com.juhwan.anyang_yi.data.api
 
 import okhttp3.ResponseBody
 import retrofit2.Response
-import retrofit2.http.FieldMap
-import retrofit2.http.FormUrlEncoded
-import retrofit2.http.POST
+import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface UnivApi {
-    @FormUrlEncoded
-    @POST("notice.do")
-    fun getUnivNoticeList(@FieldMap fields: MutableMap<String, String>): Response<ResponseBody>
+    @GET("notice.do?mode=list")
+    fun getUnivNoticeList(
+        @Query("srCategory") categoryId: String,
+        @Query("article.offset") offset: String
+    ): Response<ResponseBody>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/KakaoMapper.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/KakaoMapper.kt
@@ -14,7 +14,8 @@ object KakaoMapper {
                     isNew = DateUtil.getLeftDay(i.created_at) < 2,
                     url = i.media[0].small_url,
                     title = i.title,
-                    date = DateUtil.millisecondToDate(i.created_at)
+                    date = DateUtil.millisecondToDate(i.created_at),
+                    webLink = i.permalink
                 )
             )
         }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/AriRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/AriRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.juhwan.anyang_yi.data.repository.ari.AriRemoteDataSource
 import com.juhwan.anyang_yi.domain.model.Ari
 import com.juhwan.anyang_yi.domain.repository.AriRepository
 import com.juhwan.anyang_yi.present.utils.Result
-import java.util.HashMap
 import javax.inject.Inject
 
 class AriRepositoryImpl @Inject constructor(
@@ -29,6 +28,15 @@ class AriRepositoryImpl @Inject constructor(
             }
         } catch (error: Exception) {
             Result.fail()
+        }
+    }
+
+    override fun getRecentAriNoticeList(): Result<List<Ari>> {
+        val result = getAriNoticeList(1)
+        return result.apply {
+            if(this.data != null && this.data.size > 5) {
+                this.data.subList(0, 5)
+            }
         }
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/NonsubjectRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/NonsubjectRepositoryImpl.kt
@@ -26,4 +26,13 @@ class NonsubjectRepositoryImpl @Inject constructor(
             Result.fail()
         }
     }
+
+    override fun getRecentNonsubjectNoticeList(): Result<List<Nonsubject>> {
+        val result = getNonsubjectNoticeList()
+        return result.apply {
+            if(this.data != null && this.data.size > 10) {
+                this.data.subList(0, 10)
+            }
+        }
+    }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/UnivRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/UnivRepositoryImpl.kt
@@ -5,21 +5,16 @@ import com.juhwan.anyang_yi.data.repository.univ.UnivRemoteDataSource
 import com.juhwan.anyang_yi.domain.model.Univ
 import com.juhwan.anyang_yi.domain.repository.UnivRepository
 import com.juhwan.anyang_yi.present.utils.Result
+import com.juhwan.anyang_yi.present.views.home.notice.univ.UnivActivity
 import javax.inject.Inject
 
 class UnivRepositoryImpl @Inject constructor(
     private val univRemoteDataSource: UnivRemoteDataSource
 ) : UnivRepository {
-    val field: MutableMap<String, String> = mutableMapOf(
-        "mode" to "list"
-    )
-
-    override fun getUnivNoticeList(): Result<List<Univ>> {
-        //field["page"] = page.toString()
-        // TODO: 리뉴얼된 홈페이지에 대응
+    override fun getUnivNoticeList(categoryId: String, offset: Int): Result<List<Univ>> {
 
         return try {
-            val response = univRemoteDataSource.getUnivNoticeList(field)
+            val response = univRemoteDataSource.getUnivNoticeList(categoryId, offset.toString())
 
             if(response.isSuccessful && response.body() != null) {
                 Result.success(UnivMapper(response.body()!!))
@@ -28,6 +23,15 @@ class UnivRepositoryImpl @Inject constructor(
             }
         } catch (error: Exception) {
             Result.fail()
+        }
+    }
+
+    override fun getRecentUnivNoticeList(): Result<List<Univ>> {
+        val result = getUnivNoticeList(UnivActivity.ALL, 0)
+        return result.apply {
+            if(this.data != null && this.data.size > 5) {
+                this.data.subList(0, 5)
+            }
         }
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/univ/UnivRemoteDataSource.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/univ/UnivRemoteDataSource.kt
@@ -4,5 +4,5 @@ import okhttp3.ResponseBody
 import retrofit2.Response
 
 interface UnivRemoteDataSource {
-    fun getUnivNoticeList(fields: MutableMap<String, String>): Response<ResponseBody>
+    fun getUnivNoticeList(categoryId: String, offset: String): Response<ResponseBody>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/univ/UnivRemoteDataSourceImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/univ/UnivRemoteDataSourceImpl.kt
@@ -9,7 +9,7 @@ class UnivRemoteDataSourceImpl @Inject constructor(
     private val univApi: UnivApi
 ) : UnivRemoteDataSource {
 
-    override fun getUnivNoticeList(fields: MutableMap<String, String>): Response<ResponseBody> {
-        return univApi.getUnivNoticeList(fields)
+    override fun getUnivNoticeList(categoryId: String, offset: String): Response<ResponseBody> {
+        return univApi.getUnivNoticeList(categoryId, offset)
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Kakao.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Kakao.kt
@@ -4,5 +4,6 @@ data class Kakao(
     val isNew: Boolean,
     val url: String,
     val title: String,
-    val date: String
+    val date: String,
+    val webLink: String
 )

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/AriRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/AriRepository.kt
@@ -5,4 +5,5 @@ import com.juhwan.anyang_yi.present.utils.Result
 
 interface AriRepository {
     fun getAriNoticeList(page: Int): Result<List<Ari>>
+    fun getRecentAriNoticeList(): Result<List<Ari>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/NonsubjectRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/NonsubjectRepository.kt
@@ -2,8 +2,8 @@ package com.juhwan.anyang_yi.domain.repository
 
 import com.juhwan.anyang_yi.domain.model.Nonsubject
 import com.juhwan.anyang_yi.present.utils.Result
-import okhttp3.ResponseBody
 
 interface NonsubjectRepository {
     fun getNonsubjectNoticeList(): Result<List<Nonsubject>>
+    fun getRecentNonsubjectNoticeList(): Result<List<Nonsubject>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/UnivRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/UnivRepository.kt
@@ -4,5 +4,6 @@ import com.juhwan.anyang_yi.domain.model.Univ
 import com.juhwan.anyang_yi.present.utils.Result
 
 interface UnivRepository {
-    fun getUnivNoticeList(): Result<List<Univ>>
+    fun getUnivNoticeList(categoryId: String, offset: Int): Result<List<Univ>>
+    fun getRecentUnivNoticeList(): Result<List<Univ>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetRecentAriListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetRecentAriListUseCase.kt
@@ -1,0 +1,12 @@
+package com.juhwan.anyang_yi.domain.usecase.ari
+
+import com.juhwan.anyang_yi.domain.model.Ari
+import com.juhwan.anyang_yi.domain.repository.AriRepository
+import com.juhwan.anyang_yi.present.utils.Result
+import javax.inject.Inject
+
+class GetRecentAriListUseCase @Inject constructor(
+    private val ariRepository: AriRepository
+) {
+    operator fun invoke(): Result<List<Ari>> = ariRepository.getRecentAriNoticeList()
+}

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/nonsubject/GetRecentNonsubjectListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/nonsubject/GetRecentNonsubjectListUseCase.kt
@@ -1,0 +1,12 @@
+package com.juhwan.anyang_yi.domain.usecase.nonsubject
+
+import com.juhwan.anyang_yi.domain.model.Nonsubject
+import com.juhwan.anyang_yi.domain.repository.NonsubjectRepository
+import com.juhwan.anyang_yi.present.utils.Result
+import javax.inject.Inject
+
+class GetRecentNonsubjectListUseCase @Inject constructor(
+    private val nonsubjectRepository: NonsubjectRepository
+) {
+    operator fun invoke(): Result<List<Nonsubject>> = nonsubjectRepository.getRecentNonsubjectNoticeList()
+}

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/univ/GetRecentUnivListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/univ/GetRecentUnivListUseCase.kt
@@ -1,0 +1,12 @@
+package com.juhwan.anyang_yi.domain.usecase.univ
+
+import com.juhwan.anyang_yi.domain.model.Univ
+import com.juhwan.anyang_yi.domain.repository.UnivRepository
+import com.juhwan.anyang_yi.present.utils.Result
+import javax.inject.Inject
+
+class GetRecentUnivListUseCase @Inject constructor(
+    private val univRepository: UnivRepository
+) {
+    operator fun invoke(): Result<List<Univ>> = univRepository.getRecentUnivNoticeList()
+}

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/univ/GetUnivListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/univ/GetUnivListUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetUnivListUseCase @Inject constructor(
     private val univRepository: UnivRepository
 ) {
-    operator fun invoke(): Result<List<Univ>> = univRepository.getUnivNoticeList()
+    operator fun invoke(categoryId: String, offset: Int): Result<List<Univ>> = univRepository.getUnivNoticeList(categoryId, offset)
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/HomeFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/HomeFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.viewModels
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 import com.juhwan.anyang_yi.R
@@ -16,12 +15,9 @@ import com.juhwan.anyang_yi.present.views.home.notice.NoticeFragment
 import com.juhwan.anyang_yi.present.views.home.social.SocialFragment
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
-    private val model: HomeViewModel by viewModels()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.model = model
         initViewPager2()
 
         binding!!.ivNotification.setOnClickListener {

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeFragment.kt
@@ -3,20 +3,18 @@ package com.juhwan.anyang_yi.present.views.home.notice
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.FragmentNoticeBinding
 import com.juhwan.anyang_yi.present.config.BaseFragment
-import com.juhwan.anyang_yi.present.views.home.RecentAriAdapter
-import com.juhwan.anyang_yi.present.views.home.RecentNonsubjectAdapter
-import com.juhwan.anyang_yi.present.views.home.RecentUnivAdapter
 import com.juhwan.anyang_yi.present.views.home.notice.ari.AriActivity
 import com.juhwan.anyang_yi.present.views.home.notice.nonsubject.NonsubjectActivity
 import com.juhwan.anyang_yi.present.views.home.notice.univ.UnivActivity
 
 class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_notice) {
-
+    private val viewModel: NoticeViewModel by viewModels()
     private lateinit var recentNonsubjectAdapter: RecentNonsubjectAdapter
     private lateinit var recentAriAdapter: RecentAriAdapter
     private lateinit var recentUnivAdapter: RecentUnivAdapter
@@ -24,20 +22,36 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initRecyclerView()
+        initView()
+        initEvent()
+    }
 
-        InitialRepository.html.observe(viewLifecycleOwner, Observer{
-            if(InitialRepository.apply.isEmpty()){
-                InitialRepository.parsingApplyNotice()
-            }
+    private fun initView(){
+        binding!!.rvAri.layoutManager = LinearLayoutManager(context)
+        recentAriAdapter = RecentAriAdapter()
+        binding!!.rvAri.adapter = recentAriAdapter
 
-            binding!!.rvNonsubject.layoutManager = LinearLayoutManager(context).also {
-                it.orientation = LinearLayoutManager.HORIZONTAL
-            }
-            recentNonsubjectAdapter = RecentNonsubjectAdapter()
-            binding!!.rvNonsubject.adapter = recentNonsubjectAdapter
-            recentNonsubjectAdapter.setList(InitialRepository.apply.subList(0, 10))
-        })
+        binding!!.rvNonsubject.layoutManager = LinearLayoutManager(context)
+        recentNonsubjectAdapter = RecentNonsubjectAdapter()
+        binding!!.rvNonsubject.adapter = recentAriAdapter
+
+        binding!!.rvUniv.layoutManager = LinearLayoutManager(context)
+        recentUnivAdapter = RecentUnivAdapter()
+        binding!!.rvUniv.adapter = recentUnivAdapter
+    }
+
+    private fun initEvent() {
+        viewModel.recentAriNoticeList.observe(viewLifecycleOwner) {
+            recentAriAdapter.setList(it)
+        }
+
+        viewModel.recentNonsubjectNoticeList.observe(viewLifecycleOwner) {
+            recentNonsubjectAdapter.setList(it)
+        }
+
+        viewModel.recentUnivNoticeList.observe(viewLifecycleOwner) {
+            recentUnivAdapter.setList(it)
+        }
 
         binding!!.tvSeeAllNonsubject.setOnClickListener {
             startActivity(Intent(context, NonsubjectActivity::class.java))
@@ -50,17 +64,5 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
         binding!!.tvSeeAllAri.setOnClickListener {
             startActivity(Intent(context, AriActivity::class.java))
         }
-    }
-
-    private fun initRecyclerView(){
-        binding!!.rvUniv.layoutManager = LinearLayoutManager(context)
-        recentUnivAdapter = RecentUnivAdapter()
-        binding!!.rvUniv.adapter = recentUnivAdapter
-        //mainNoticeAdapter.setList(InitialRepository.mainNotice)
-
-        binding!!.rvAri.layoutManager = LinearLayoutManager(context)
-        recentAriAdapter = RecentAriAdapter()
-        binding!!.rvAri.adapter = recentAriAdapter
-        recentAriAdapter.setList(InitialRepository.ariNotice)
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeViewModel.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeViewModel.kt
@@ -8,7 +8,10 @@ import com.juhwan.anyang_yi.domain.model.Ari
 import com.juhwan.anyang_yi.domain.model.Nonsubject
 import com.juhwan.anyang_yi.domain.model.Univ
 import com.juhwan.anyang_yi.domain.usecase.ari.GetAriListUseCase
+import com.juhwan.anyang_yi.domain.usecase.ari.GetRecentAriListUseCase
 import com.juhwan.anyang_yi.domain.usecase.nonsubject.GetNonsubjectListUseCase
+import com.juhwan.anyang_yi.domain.usecase.nonsubject.GetRecentNonsubjectListUseCase
+import com.juhwan.anyang_yi.domain.usecase.univ.GetRecentUnivListUseCase
 import com.juhwan.anyang_yi.domain.usecase.univ.GetUnivListUseCase
 import com.juhwan.anyang_yi.present.utils.Result
 import com.juhwan.anyang_yi.present.utils.Status
@@ -18,49 +21,49 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NoticeViewModel @Inject constructor(
-    private val getAriListUseCase: GetAriListUseCase,
-    private val getNonsubjectListUseCase: GetNonsubjectListUseCase,
-    private val getUnivListUseCase: GetUnivListUseCase
+    private val getRecentAriListUseCase: GetRecentAriListUseCase,
+    private val getRecentNonsubjectListUseCase: GetRecentNonsubjectListUseCase,
+    private val getRecentUnivListUseCase: GetRecentUnivListUseCase
 ): ViewModel() {
-    private val _AriNoticeList = MutableLiveData<List<Ari>>()
-    val ariNoticeList: LiveData<List<Ari>> get() = _AriNoticeList
+    private val _recentAriNoticeList = MutableLiveData<List<Ari>>()
+    val recentAriNoticeList: LiveData<List<Ari>> get() = _recentAriNoticeList
 
-    private val _NonsubjectNoticeList = MutableLiveData<List<Nonsubject>>()
-    val nonsubjectNoticeList: LiveData<List<Nonsubject>> get() = _NonsubjectNoticeList
+    private val _recentNonsubjectNoticeList = MutableLiveData<List<Nonsubject>>()
+    val recentNonsubjectNoticeList: LiveData<List<Nonsubject>> get() = _recentNonsubjectNoticeList
 
-    private val _UnivNoticeList = MutableLiveData<List<Univ>>()
-    val univNoticeList: LiveData<List<Univ>> get() = _UnivNoticeList
+    private val _recentUnivNoticeList = MutableLiveData<List<Univ>>()
+    val recentUnivNoticeList: LiveData<List<Univ>> get() = _recentUnivNoticeList
 
     private val _problem = MutableLiveData<Result<Any>>()
     val problem: LiveData<Result<Any>> get() = _problem
 
-    fun getAriNoticeList(page: Int) {
+    fun getRecentAriNoticeList() {
         viewModelScope.launch {
-            val result = getAriListUseCase(page)
+            val result = getRecentAriListUseCase()
             if(result.status == Status.SUCCESS) {
-                result.data.let { _AriNoticeList.postValue(it) }
+                result.data.let { _recentAriNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }
         }
     }
 
-    fun getNonsubjectNoticeList() {
+    fun getRecentNonsubjectNoticeList() {
         viewModelScope.launch {
-            val result = getNonsubjectListUseCase()
+            val result = getRecentNonsubjectListUseCase()
             if(result.status == Status.SUCCESS) {
-                result.data.let { _NonsubjectNoticeList.postValue(it) }
+                result.data.let { _recentNonsubjectNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }
         }
     }
 
-    fun getUnivNoticeList() {
+    fun getRecentUnivNoticeList() {
         viewModelScope.launch {
-            val result = getUnivListUseCase()
+            val result = getRecentUnivListUseCase()
             if(result.status == Status.SUCCESS) {
-                result.data.let { _UnivNoticeList.postValue(it) }
+                result.data.let { _recentUnivNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentAriAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentAriAdapter.kt
@@ -1,16 +1,16 @@
-package com.juhwan.anyang_yi.present.views.home
+package com.juhwan.anyang_yi.present.views.home.notice
 
 import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.juhwan.anyang_yi.data.model.AriNoticeList
 import com.juhwan.anyang_yi.databinding.ItemNoticeBinding
+import com.juhwan.anyang_yi.domain.model.Ari
+import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class RecentAriAdapter : RecyclerView.Adapter<RecentAriAdapter.AriNoticeViewHolder>() {
-    private val items = ArrayList<AriNoticeList>()
-    private val baseUrl = "https://ari.anyang.ac.kr/user/bbs/notice/"
+    private val items = ArrayList<Ari>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : AriNoticeViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -26,20 +26,16 @@ class RecentAriAdapter : RecyclerView.Adapter<RecentAriAdapter.AriNoticeViewHold
         holder.bind(items[position])
     }
 
-    fun setList(ariNotice: MutableList<AriNoticeList>) {
+    fun setList(ariNotice: List<Ari>) {
         items.addAll(ariNotice)
     }
 
     inner class AriNoticeViewHolder(private val binding: ItemNoticeBinding):RecyclerView.ViewHolder(binding.root){
-        fun bind(ariNotice: AriNoticeList){
+        fun bind(ariNotice: Ari){
             binding.tvNoticeTitle.text = ariNotice.title
             binding.tvNoticeDate.text = ariNotice.date
 
-            var hms2 = ariNotice.date + " 00:00:00"
-            var writeDate = InitialRepository.sf.parse(hms2)
-            var calculateDate = (InitialRepository.todayDate.time - writeDate.time) / (60 * 60 * 24 * 1000)
-
-            if(calculateDate.toInt() == 0){
+            if(ariNotice.date == "0"){
                 binding.ivNew.visibility = View.VISIBLE
             } else {
                 binding.ivNew.visibility = View.GONE
@@ -48,7 +44,7 @@ class RecentAriAdapter : RecyclerView.Adapter<RecentAriAdapter.AriNoticeViewHold
             binding.layoutNotice.setOnClickListener {
                 var goPage = Intent(it.context, WebViewActivity::class.java)
 
-                goPage.putExtra("url", baseUrl + ariNotice.link)
+                goPage.putExtra("url", ariNotice.link)
                 it.context.startActivity(goPage)
             }
         }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentNonsubjectAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentNonsubjectAdapter.kt
@@ -1,4 +1,4 @@
-package com.juhwan.anyang_yi.present.views.home
+package com.juhwan.anyang_yi.present.views.home.notice
 
 import android.content.Intent
 import android.view.LayoutInflater
@@ -8,11 +8,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestOptions
 import com.juhwan.anyang_yi.databinding.ItemRecentNonsubjectBinding
+import com.juhwan.anyang_yi.domain.model.Nonsubject
+import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class RecentNonsubjectAdapter : RecyclerView.Adapter<RecentNonsubjectAdapter.ApplyViewHolder>() {
-    private val items = ArrayList<NonsubjectEntity>()
-    private val baseImageUrl = "http://ari.anyang.ac.kr"
-    private val baseUrl = "https://ari.anyang.ac.kr/user/subject/nsubject/"
+    private val items = ArrayList<Nonsubject>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ApplyViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -28,17 +28,17 @@ class RecentNonsubjectAdapter : RecyclerView.Adapter<RecentNonsubjectAdapter.App
         holder.bind(items[position])
     }
 
-    fun setList(nonsubjectEntity: List<NonsubjectEntity>) {
+    fun setList(nonsubjectEntity: List<Nonsubject>) {
         items.addAll(nonsubjectEntity)
     }
 
     inner class ApplyViewHolder(private val binding: ItemRecentNonsubjectBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(nonsubjectEntity: NonsubjectEntity) {
-            binding.tvTitle.text = nonsubjectEntity.title
-            binding.tvDDay.text = nonsubjectEntity.dDay
+        fun bind(nonsubject: Nonsubject) {
+            binding.tvTitle.text = nonsubject.title
+            binding.tvDDay.text = nonsubject.leftDay
 
-            Glide.with(itemView.context).load(baseImageUrl + nonsubjectEntity.imageUrl).fitCenter()
+            Glide.with(itemView.context).load(nonsubject.imageUrl).fitCenter()
                 .apply(
                     RequestOptions.bitmapTransform(RoundedCorners(20))
                 ).into(binding.ivThumbnail)
@@ -46,7 +46,7 @@ class RecentNonsubjectAdapter : RecyclerView.Adapter<RecentNonsubjectAdapter.App
             binding.clNonsubject.setOnClickListener {
                 var goPage = Intent(it.context, WebViewActivity::class.java)
 
-                goPage.putExtra("url", baseUrl + nonsubjectEntity.idx)
+                goPage.putExtra("url", nonsubject.webLink)
                 it.context.startActivity(goPage)
             }
         }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentUnivAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/RecentUnivAdapter.kt
@@ -1,14 +1,16 @@
-package com.juhwan.anyang_yi.present.views.home
+package com.juhwan.anyang_yi.present.views.home.notice
 
+import android.content.Intent
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.juhwan.anyang_yi.data.model.ResultList
 import com.juhwan.anyang_yi.databinding.ItemNoticeBinding
+import com.juhwan.anyang_yi.domain.model.Univ
+import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class RecentUnivAdapter : RecyclerView.Adapter<RecentUnivAdapter.MainNoticeViewHolder>() {
-    private val items = ArrayList<ResultList>()
-    private val baseUrl = "http://www.anyang.ac.kr/bbs/boardView.do?bsIdx=61&menuId=23&bcIdx=20&bIdx="
+    private val items = ArrayList<Univ>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : MainNoticeViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -24,23 +26,16 @@ class RecentUnivAdapter : RecyclerView.Adapter<RecentUnivAdapter.MainNoticeViewH
         holder.bind(items[position])
     }
 
-    fun setList(notice: MutableList<ResultList>) {
+    fun setList(notice: List<Univ>) {
         items.addAll(notice)
     }
 
     inner class MainNoticeViewHolder(private val binding: ItemNoticeBinding): RecyclerView.ViewHolder(binding.root){
-        fun bind(notice: ResultList){
-            //binding.resultList = notice
+        fun bind(notice: Univ){
+            binding.tvNoticeTitle.text = notice.title
+            binding.tvNoticeDate.text = notice.date
 
-            /*
-            binding.tvNoticeTitle.text = notice.SUBJECT
-            binding.tvNoticeDate.text = notice.WRITE_DATE2 + "   |   " + notice.WRITER
-
-            var hms2 = notice.WRITE_DATE2 + " 00:00:00"
-            var writeDate = InitialRepository.sf.parse(hms2)
-            var calculateDate = (InitialRepository.todayDate.time - writeDate.time) / (60 * 60 * 24 * 1000)
-
-            if(calculateDate.toInt() == 0){
+            if(notice.isNew){
                 binding.ivNew.visibility = View.VISIBLE
             } else {
                 binding.ivNew.visibility = View.GONE
@@ -49,11 +44,9 @@ class RecentUnivAdapter : RecyclerView.Adapter<RecentUnivAdapter.MainNoticeViewH
             binding.layoutNotice.setOnClickListener {
                 var goPage = Intent(it.context, WebViewActivity::class.java)
 
-                goPage.putExtra("url", baseUrl + notice.B_IDX)
+                goPage.putExtra("url", notice.url)
                 it.context.startActivity(goPage)
             }
-
-             */
         }
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriActivity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriActivity.kt
@@ -2,16 +2,16 @@ package com.juhwan.anyang_yi.present.views.home.notice.ari
 
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.ActivityAriBinding
 import com.juhwan.anyang_yi.present.config.BaseActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AriActivity : BaseActivity<ActivityAriBinding>(R.layout.activity_ari) {
-
-    private val model: AriViewModel by viewModels()
+    private val viewModel: AriViewModel by viewModels()
     private lateinit var ariAdapter: AriAdapter
     private var page = 1
 
@@ -19,16 +19,29 @@ class AriActivity : BaseActivity<ActivityAriBinding>(R.layout.activity_ari) {
         super.onCreate(savedInstanceState)
 
         initRecyclerView()
-        model.loadAriNotice(page)
+        initEvent()
+        viewModel.getAriNoticeList(page)
+    }
 
+    private fun initRecyclerView(){
+        binding.rvAriNotice.layoutManager = LinearLayoutManager(this)
+        ariAdapter = AriAdapter()
+        binding.rvAriNotice.adapter = ariAdapter
+    }
+
+    private fun initEvent() {
         binding.ivBack.setOnClickListener {
             finish()
         }
 
-        model.getAll().observe(this, Observer {
-            ariAdapter.setList(it.ariNotice)
+        viewModel.ariNoticeList.observe(this) {
+            ariAdapter.setList(it)
             ariAdapter.notifyItemRangeInserted((page - 1) * 10, 10)
-        })
+        }
+
+        viewModel.problem.observe(this) {
+            showToastMessage(resources.getString(R.string.network_error))
+        }
 
         binding.rvAriNotice.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
@@ -42,16 +55,9 @@ class AriActivity : BaseActivity<ActivityAriBinding>(R.layout.activity_ari) {
                     lastVisibleItemPosition == itemTotalCount
                 ) {
                     ariAdapter.deleteLoading()
-                    model.loadAriNotice(++page)
+                    viewModel.getAriNoticeList(++page)
                 }
-
             }
         })
-    }
-
-    private fun initRecyclerView(){
-        binding.rvAriNotice.layoutManager = LinearLayoutManager(this)
-        ariAdapter = AriAdapter()
-        binding.rvAriNotice.adapter = ariAdapter
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriAdapter.kt
@@ -5,9 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.juhwan.anyang_yi.data.model.AriNoticeList
 import com.juhwan.anyang_yi.databinding.ItemLoadingBinding
 import com.juhwan.anyang_yi.databinding.ItemNoticeBinding
+import com.juhwan.anyang_yi.domain.model.Ari
 import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class AriAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -16,20 +16,16 @@ class AriAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val VIEW_TYPE_LOADING = 1
     private val baseUrl = "https://ari.anyang.ac.kr/user/bbs/notice/"
 
-    private var items = ArrayList<AriNoticeList>()
+    private var items = ArrayList<Ari>()
 
     inner class NoticeViewHolder(private val binding: ItemNoticeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(notice: AriNoticeList) {
+        fun bind(notice: Ari) {
             binding.tvNoticeTitle.text = notice.title
             binding.tvNoticeDate.text = notice.date
 
-            var hms2 = notice.date + " 00:00:00"
-            var writeDate = InitialRepository.sf.parse(hms2)
-            var calculateDate = (InitialRepository.todayDate.time - writeDate.time) / (60 * 60 * 24 * 1000)
-
-            if(calculateDate.toInt() == 0){
+            if(notice.date == "0"){
                 binding.ivNew.visibility = View.VISIBLE
             } else {
                 binding.ivNew.visibility = View.GONE
@@ -84,7 +80,7 @@ class AriAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
-    fun setList(notice: ArrayList<AriNoticeList>) {
+    fun setList(notice: List<Ari>) {
         items.addAll(notice)
     }
 

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriViewModel.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/ari/AriViewModel.kt
@@ -20,8 +20,8 @@ class AriViewModel @Inject constructor(
     private val getNonsubjectListUseCase: GetNonsubjectListUseCase,
     private val getUnivListUseCase: GetUnivListUseCase
 ): ViewModel() {
-    private val _AriNoticeList = MutableLiveData<List<Ari>>()
-    val ariNoticeList: LiveData<List<Ari>> get() = _AriNoticeList
+    private val _ariNoticeList = MutableLiveData<List<Ari>>()
+    val ariNoticeList: LiveData<List<Ari>> get() = _ariNoticeList
 
     private val _problem = MutableLiveData<Result<Any>>()
     val problem: LiveData<Result<Any>> get() = _problem
@@ -30,7 +30,7 @@ class AriViewModel @Inject constructor(
         viewModelScope.launch {
             val result = getAriListUseCase(page)
             if(result.status == Status.SUCCESS) {
-                result.data.let { _AriNoticeList.postValue(it) }
+                result.data.let { _ariNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectActivity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectActivity.kt
@@ -1,18 +1,34 @@
 package com.juhwan.anyang_yi.present.views.home.notice.nonsubject
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.ActivityNonsubjectBinding
 import com.juhwan.anyang_yi.present.config.BaseActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class NonsubjectActivity : BaseActivity<ActivityNonsubjectBinding>(R.layout.activity_nonsubject) {
+    private val viewModel: NonsubjectViewModel by viewModels()
     private lateinit var nonsubjectAdapter: NonsubjectAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        initRecyclerView()
 
+        initView()
+        initEvent()
+        viewModel.getNonsubjectNoticeList()
+    }
+
+    private fun initView(){
+        binding.rvNonsubject.layoutManager = GridLayoutManager(this, 2)
+        nonsubjectAdapter = NonsubjectAdapter()
+        binding.rvNonsubject.adapter = nonsubjectAdapter
+
+    }
+
+    private fun initEvent() {
         binding.radioGroupFilter.setOnCheckedChangeListener { _, checkedId ->
             when(checkedId){
                 R.id.rb_new -> nonsubjectAdapter.arrangeList(0)
@@ -20,16 +36,17 @@ class NonsubjectActivity : BaseActivity<ActivityNonsubjectBinding>(R.layout.acti
             }
         }
 
-        binding.tvNumber.text = InitialRepository.apply.size.toString()
+        viewModel.nonsubjectNoticeList.observe(this) {
+            nonsubjectAdapter.setList(it)
+            binding.tvNumber.text = it.size.toString()
+        }
+
+        viewModel.problem.observe(this) {
+            showToastMessage(resources.getString(R.string.network_error))
+        }
+
         binding.ivBack.setOnClickListener {
             finish()
         }
-    }
-
-    private fun initRecyclerView(){
-        binding.rvNonsubject.layoutManager = GridLayoutManager(this, 2)
-        nonsubjectAdapter = NonsubjectAdapter()
-        binding.rvNonsubject.adapter = nonsubjectAdapter
-        nonsubjectAdapter.setList(InitialRepository.apply)
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectAdapter.kt
@@ -8,12 +8,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestOptions
 import com.juhwan.anyang_yi.databinding.ItemNonsubjectBinding
+import com.juhwan.anyang_yi.domain.model.Nonsubject
 import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class NonsubjectAdapter : RecyclerView.Adapter<NonsubjectAdapter.AllApplyViewHolder>() {
-    private val items = ArrayList<NonsubjectEntity>()
-    private val baseImageUrl = "http://ari.anyang.ac.kr"
-    private val baseUrl = "https://ari.anyang.ac.kr/user/subject/nsubject/"
+    private val items = ArrayList<Nonsubject>()
     private var arrangeValue = 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AllApplyViewHolder {
@@ -30,7 +29,7 @@ class NonsubjectAdapter : RecyclerView.Adapter<NonsubjectAdapter.AllApplyViewHol
         holder.bind(items[position])
     }
 
-    fun setList(nonsubjectEntity: List<NonsubjectEntity>) {
+    fun setList(nonsubjectEntity: List<Nonsubject>) {
         items.addAll(nonsubjectEntity)
     }
 
@@ -44,14 +43,14 @@ class NonsubjectAdapter : RecyclerView.Adapter<NonsubjectAdapter.AllApplyViewHol
 
     inner class AllApplyViewHolder(private val binding: ItemNonsubjectBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(nonsubjectEntity: NonsubjectEntity) {
-            binding.tvTitle.text = nonsubjectEntity.title
-            binding.tvTrainingPeriod.text = "기간: " + nonsubjectEntity.trainingPeriod.substring(5, nonsubjectEntity.trainingPeriod.length)
-            binding.tvApplicant.text = "인원: " + nonsubjectEntity.applicant
+        fun bind(nonsubject: Nonsubject) {
+            binding.tvTitle.text = nonsubject.title
+            binding.tvTrainingPeriod.text = nonsubject.trainingPeriod
+            binding.tvApplicant.text = nonsubject.applicant
 
-            binding.tvDDay.text = nonsubjectEntity.dDay
+            binding.tvDDay.text = nonsubject.leftDay
 
-            Glide.with(itemView.context).load(baseImageUrl + nonsubjectEntity.imageUrl).fitCenter()
+            Glide.with(itemView.context).load(nonsubject.imageUrl).fitCenter()
                 .apply(
                     RequestOptions.bitmapTransform(RoundedCorners(20))
                 ).into(binding.ivThumbnail)
@@ -59,7 +58,7 @@ class NonsubjectAdapter : RecyclerView.Adapter<NonsubjectAdapter.AllApplyViewHol
             binding.layoutApply.setOnClickListener {
                 var goPage = Intent(it.context, WebViewActivity::class.java)
 
-                goPage.putExtra("url", baseUrl + nonsubjectEntity.idx)
+                goPage.putExtra("url", nonsubject.webLink)
                 it.context.startActivity(goPage)
             }
         }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectViewModel.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectViewModel.kt
@@ -17,8 +17,8 @@ class NonsubjectViewModel @Inject constructor(
     private val getNonsubjectListUseCase: GetNonsubjectListUseCase,
 ): ViewModel() {
 
-    private val _NonsubjectNoticeList = MutableLiveData<List<Nonsubject>>()
-    val nonsubjectNoticeList: LiveData<List<Nonsubject>> get() = _NonsubjectNoticeList
+    private val _nonsubjectNoticeList = MutableLiveData<List<Nonsubject>>()
+    val nonsubjectNoticeList: LiveData<List<Nonsubject>> get() = _nonsubjectNoticeList
 
     private val _problem = MutableLiveData<Result<Any>>()
     val problem: LiveData<Result<Any>> get() = _problem
@@ -27,7 +27,7 @@ class NonsubjectViewModel @Inject constructor(
         viewModelScope.launch {
             val result = getNonsubjectListUseCase()
             if(result.status == Status.SUCCESS) {
-                result.data.let { _NonsubjectNoticeList.postValue(it) }
+                result.data.let { _nonsubjectNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivActivity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivActivity.kt
@@ -2,37 +2,46 @@ package com.juhwan.anyang_yi.present.views.home.notice.univ
 
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.tabs.TabLayout
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.ActivityUnivBinding
 import com.juhwan.anyang_yi.present.config.BaseActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class UnivActivity : BaseActivity<ActivityUnivBinding>(R.layout.activity_univ) {
-    private val model: UnivViewModel by viewModels()
+    private val viewModel: UnivViewModel by viewModels()
     private lateinit var univAdapter: UnivAdapter
-    private var page = 1
-    private var bcIdx = "0"
     private var isListEmpty = true
+    private var categoryId = ALL
+    private var offset = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         initRecyclerView()
         initTabLayout()
-        model.loadMainNotice(page, bcIdx)
+        viewModel.getUnivNoticeList(categoryId, offset)
 
+        initEvent()
+    }
+
+    private fun initEvent() {
         binding.ivBack.setOnClickListener {
             finish()
         }
 
-        model.getAll().observe(this, Observer {
-            univAdapter.setList(it.resultList)
+        viewModel.univNoticeList.observe(this) {
+            univAdapter.setList(it)
             isListEmpty = false
-            univAdapter.notifyItemRangeInserted((page - 1) * 15, 15)
-        })
+            univAdapter.notifyItemRangeInserted(offset * 10, 10)
+        }
+
+        viewModel.problem.observe(this) {
+            showToastMessage(resources.getString(R.string.network_error))
+        }
 
         binding.rvUnivNotice.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
@@ -46,7 +55,7 @@ class UnivActivity : BaseActivity<ActivityUnivBinding>(R.layout.activity_univ) {
                     lastVisibleItemPosition == itemTotalCount && !isListEmpty
                 ) {
                     univAdapter.deleteLoading()
-                    model.loadMainNotice(++page, bcIdx)
+                    viewModel.getUnivNoticeList(categoryId, ++offset)
                 }
             }
         })
@@ -70,23 +79,31 @@ class UnivActivity : BaseActivity<ActivityUnivBinding>(R.layout.activity_univ) {
             }
 
             override fun onTabSelected(tab: TabLayout.Tab?) {
-                // bcIdx
-                // 전체(0), 대학교(20), 학사(80), 학사(21), 취업정보(23), 입찰채용(24)
-                when(tab!!.position){
-                    0 -> bcIdx = "0"
-                    1 -> bcIdx = "20"
-                    2 -> bcIdx = "80"
-                    3 -> bcIdx = "21"
-                    4 -> bcIdx = "23"
-                    5 -> bcIdx = "24"
+                categoryId = when(tab!!.position){
+                    1 -> UNIV
+                    2 -> BACHELOR
+                    3 -> GRADUATE_SCHOOL
+                    4 -> JOB
+                    5 -> BID
+                    else -> ALL
                 }
 
-                page = 1
-                univAdapter.resetList(bcIdx)
+                offset = 1
+                univAdapter.resetList()
                 isListEmpty = true
                 univAdapter.notifyDataSetChanged()
-                model.loadMainNotice(page, bcIdx)
+                viewModel.getUnivNoticeList(categoryId, offset)
             }
         })
+    }
+
+    // 전체(null), 대학교(17), 학사(18), 대학원(19), 취업정보(20), 입찰채용(21)
+    companion object {
+        const val ALL = "-1"
+        const val UNIV = "17"
+        const val BACHELOR = "18"
+        const val GRADUATE_SCHOOL = "19"
+        const val JOB = "20"
+        const val BID = "21"
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivAdapter.kt
@@ -5,32 +5,25 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.juhwan.anyang_yi.data.model.ResultList
 import com.juhwan.anyang_yi.databinding.ItemLoadingBinding
 import com.juhwan.anyang_yi.databinding.ItemNoticeBinding
-import com.juhwan.anyang_yi.data.repository.InitialRepository.sf
+import com.juhwan.anyang_yi.domain.model.Univ
 import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class UnivAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-
     private val VIEW_TYPE_ITEM = 0
     private val VIEW_TYPE_LOADING = 1
-    private var baseUrl = "http://www.anyang.ac.kr/bbs/boardView.do?bsIdx=61&menuId=23&bcIdx=20&bIdx="
 
-    private var items = ArrayList<ResultList>()
+    private var items = ArrayList<Univ>()
 
     inner class NoticeViewHolder(private val binding: ItemNoticeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(notice: ResultList) {
-            binding.tvNoticeTitle.text = notice.SUBJECT
-            binding.tvNoticeDate.text = notice.WRITE_DATE2 + "   |   " + notice.WRITER
+        fun bind(notice: Univ) {
+            binding.tvNoticeTitle.text = notice.title
+            binding.tvNoticeDate.text = notice.date
 
-            var hms2 = notice.WRITE_DATE2 + " 00:00:00"
-            var writeDate = sf.parse(hms2)
-            var calculateDate = (InitialRepository.todayDate.time - writeDate.time) / (60 * 60 * 24 * 1000)
-
-            if(calculateDate.toInt() == 0){
+            if(notice.isNew){
                 binding.ivNew.visibility = View.VISIBLE
             } else {
                 binding.ivNew.visibility = View.GONE
@@ -39,7 +32,7 @@ class UnivAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             binding.layoutNotice.setOnClickListener {
                 var goUnivHomepage = Intent(it.context, WebViewActivity::class.java)
 
-                goUnivHomepage.putExtra("url", baseUrl + notice.B_IDX)
+                goUnivHomepage.putExtra("url", notice.url)
                 it.context.startActivity(goUnivHomepage)
             }
         }
@@ -52,10 +45,11 @@ class UnivAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     // 뷰의 타입을 정해주는 곳이다.
     override fun getItemViewType(position: Int): Int {
-        return when (items[position].SUBJECT) {
-            " " -> VIEW_TYPE_LOADING
-            else -> VIEW_TYPE_ITEM
-        }
+//        return when (items[position].SUBJECT) {
+//            " " -> VIEW_TYPE_LOADING
+//            else -> VIEW_TYPE_ITEM
+//        }
+        return VIEW_TYPE_ITEM
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -85,13 +79,12 @@ class UnivAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
-    fun setList(notice: ArrayList<ResultList>) {
+    fun setList(notice: List<Univ>) {
         items.addAll(notice)
     }
 
-    fun resetList(bcIdx: String) {
+    fun resetList() {
         items.clear()
-        baseUrl = "http://www.anyang.ac.kr/bbs/boardView.do?bsIdx=61&menuId=23&bcIdx=$bcIdx&bIdx="
     }
 
     fun deleteLoading(){

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivViewModel.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/univ/UnivViewModel.kt
@@ -17,17 +17,17 @@ class UnivViewModel @Inject constructor(
     private val getUnivListUseCase: GetUnivListUseCase
 ): ViewModel() {
 
-    private val _UnivNoticeList = MutableLiveData<List<Univ>>()
-    val univNoticeList: LiveData<List<Univ>> get() = _UnivNoticeList
+    private val _univNoticeList = MutableLiveData<List<Univ>>()
+    val univNoticeList: LiveData<List<Univ>> get() = _univNoticeList
 
     private val _problem = MutableLiveData<Result<Any>>()
     val problem: LiveData<Result<Any>> get() = _problem
 
-    fun getUnivNoticeList() {
+    fun getUnivNoticeList(categoryId: String, offset: Int) {
         viewModelScope.launch {
-            val result = getUnivListUseCase()
+            val result = getUnivListUseCase(categoryId, offset)
             if(result.status == Status.SUCCESS) {
-                result.data.let { _UnivNoticeList.postValue(it) }
+                result.data.let { _univNoticeList.postValue(it) }
             } else {
                 _problem.postValue(result)
             }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/KakaoAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/KakaoAdapter.kt
@@ -9,18 +9,12 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestOptions
 import com.juhwan.anyang_yi.R
-import com.juhwan.anyang_yi.data.model.Item
 import com.juhwan.anyang_yi.databinding.ItemKakaoBinding
+import com.juhwan.anyang_yi.domain.model.Kakao
 import com.juhwan.anyang_yi.present.views.home.WebViewActivity
-import java.text.SimpleDateFormat
 
-class KakaoAdapter(items: ArrayList<Item>) : RecyclerView.Adapter<KakaoAdapter.KakaoViewHolder>() {
-    private val items = ArrayList<Item>()
-    private val sdf = SimpleDateFormat("yyyy-MM-dd")
-
-    init {
-        this.items.addAll(items.subList(0, 10))
-    }
+class KakaoAdapter : RecyclerView.Adapter<KakaoAdapter.KakaoViewHolder>() {
+    private val items = ArrayList<Kakao>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KakaoViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -36,32 +30,28 @@ class KakaoAdapter(items: ArrayList<Item>) : RecyclerView.Adapter<KakaoAdapter.K
         holder.bind(items[position])
     }
 
+    fun setList(list: List<Kakao>) {
+        items.clear()
+        items.addAll(list)
+    }
+
     inner class KakaoViewHolder(private val binding: ItemKakaoBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(kakaoNotice: Item) {
-            var date = sdf.format(kakaoNotice.created_at)
+        fun bind(kakaoNotice: Kakao) {
             binding.tvTitle.text = kakaoNotice.title
-            binding.tvDate.text = date
+            binding.tvDate.text = kakaoNotice.date
 
-            var hms2 = "$date 00:00:00"
-            var writeDate = InitialRepository.sf.parse(hms2)
-            var calculateDate = (InitialRepository.todayDate.time - writeDate.time) / (60 * 60 * 24 * 1000)
-
-            if(calculateDate.toInt() < 2){
+            if(kakaoNotice.isNew){
                 binding.ivNew.visibility = View.VISIBLE
             } else {
                 binding.ivNew.visibility = View.GONE
             }
 
             try{
-                if(kakaoNotice.media[0].small_url.isNotEmpty()){
-                    Glide.with(itemView.context).load(kakaoNotice.media[0].small_url).fitCenter()
-                        .apply(
-                            RequestOptions.bitmapTransform(RoundedCorners(20))
-                        ).into(binding.ivThumbnail)
-                } else {
-                    setDefaultImage()
-                }
+                Glide.with(itemView.context).load(kakaoNotice.url).fitCenter()
+                    .apply(
+                        RequestOptions.bitmapTransform(RoundedCorners(20))
+                    ).into(binding.ivThumbnail)
             } catch (e: Exception){
                 setDefaultImage()
             }
@@ -69,12 +59,12 @@ class KakaoAdapter(items: ArrayList<Item>) : RecyclerView.Adapter<KakaoAdapter.K
             binding.clKakaoNotice.setOnClickListener {
                 var goPage = Intent(it.context, WebViewActivity::class.java)
 
-                goPage.putExtra("url", kakaoNotice.permalink)
+                goPage.putExtra("url", kakaoNotice.webLink)
                 it.context.startActivity(goPage)
             }
         }
 
-        fun setDefaultImage(){
+        private fun setDefaultImage(){
             Glide.with(itemView.context).load(R.drawable.no_image).fitCenter()
                 .apply(
                     RequestOptions.bitmapTransform(RoundedCorners(20))

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/SocialFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/SocialFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.juhwan.anyang_yi.R
@@ -12,6 +13,7 @@ import com.juhwan.anyang_yi.present.config.BaseFragment
 import com.juhwan.anyang_yi.present.views.home.WebViewActivity
 
 class SocialFragment : BaseFragment<FragmentSocialBinding>(R.layout.fragment_social) {
+    private val viewModel: SocialViewModel by viewModels()
     private lateinit var eduAdapter: KakaoAdapter
     private lateinit var jobAdapter: KakaoAdapter
     private lateinit var ariPanelAdapter: KakaoAdapter
@@ -19,16 +21,49 @@ class SocialFragment : BaseFragment<FragmentSocialBinding>(R.layout.fragment_soc
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if(KakaoRepository_.isFinished.value == null){
-            KakaoRepository_.loadInitialData()
-            binding!!.lottieSheep.visibility = View.VISIBLE
-            binding!!.lottieSheep.playAnimation()
+        viewModel.getEduNoticeList()
+        viewModel.getJobNoticeList()
+        viewModel.getAriPanelNoticeList()
+        initView()
+        initEvent()
+    }
+
+    private fun initView(){
+        binding!!.rvEdu.layoutManager = LinearLayoutManager(context).also {
+            it.orientation = LinearLayoutManager.HORIZONTAL
+        }
+        eduAdapter = KakaoAdapter()
+        binding!!.rvEdu.adapter = eduAdapter
+
+        binding!!.rvJob.layoutManager = LinearLayoutManager(context).also {
+            it.orientation = LinearLayoutManager.HORIZONTAL
+        }
+        jobAdapter = KakaoAdapter()
+        binding!!.rvJob.adapter = jobAdapter
+
+        binding!!.rvAriPanel.layoutManager = LinearLayoutManager(context).also {
+            it.orientation = LinearLayoutManager.HORIZONTAL
+        }
+        ariPanelAdapter = KakaoAdapter()
+        binding!!.rvAriPanel.adapter = ariPanelAdapter
+    }
+
+    private fun initEvent() {
+        viewModel.eduNoticeList.observe(viewLifecycleOwner) {
+            eduAdapter.setList(it)
         }
 
-        KakaoRepository_.isFinished.observe(viewLifecycleOwner, Observer{
-            binding!!.lottieSheep.visibility = View.GONE
-            initRecyclerView()
-        })
+        viewModel.jobNoticeList.observe(viewLifecycleOwner) {
+            jobAdapter.setList(it)
+        }
+
+        viewModel.ariPanelNoticeList.observe(viewLifecycleOwner) {
+            ariPanelAdapter.setList(it)
+        }
+
+        viewModel.problem.observe(viewLifecycleOwner) {
+            showToastMessage(resources.getString(R.string.network_error))
+        }
 
         binding!!.tvSeeAllEdu.setOnClickListener {
             //startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://plus.kakao.com/home/@jxehRd")))
@@ -40,26 +75,6 @@ class SocialFragment : BaseFragment<FragmentSocialBinding>(R.layout.fragment_soc
         binding!!.tvSeeAllAriPanel.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://pf.kakao.com/_lNmNd")))
         }
-    }
-
-    private fun initRecyclerView(){
-        binding!!.rvEdu.layoutManager = LinearLayoutManager(context).also {
-            it.orientation = LinearLayoutManager.HORIZONTAL
-        }
-        eduAdapter = KakaoAdapter(KakaoRepository_.eduNotice)
-        binding!!.rvEdu.adapter = eduAdapter
-
-        binding!!.rvJob.layoutManager = LinearLayoutManager(context).also {
-            it.orientation = LinearLayoutManager.HORIZONTAL
-        }
-        jobAdapter = KakaoAdapter(KakaoRepository_.jobNotice)
-        binding!!.rvJob.adapter = jobAdapter
-
-        binding!!.rvAriPanel.layoutManager = LinearLayoutManager(context).also {
-            it.orientation = LinearLayoutManager.HORIZONTAL
-        }
-        ariPanelAdapter = KakaoAdapter(KakaoRepository_.ariPanelNotice)
-        binding!!.rvAriPanel.adapter = ariPanelAdapter
     }
 
     private fun goPage(url: String){

--- a/PushNotification/app/src/main/res/layout/fragment_home.xml
+++ b/PushNotification/app/src/main/res/layout/fragment_home.xml
@@ -3,11 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
-    <data>
-        <variable
-            name="model"
-            type="com.juhwan.anyang_yi.present.views.home.HomeViewModel" />
-    </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"

--- a/PushNotification/app/src/main/res/values/strings.xml
+++ b/PushNotification/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     </string>
     <string name="my_comment">\"앞으로도 많이 이용해주세요\"</string>
     <string name="helper_comment">\"도와주셔서 감사합니다\"</string>
+    <string name="network_error">네트워크 상태를 확인해주세요</string>
 
     <string name="mit_license">MIT License\n\n
 


### PR DESCRIPTION
repositoryImpl, usecase, viewModel, adapter에
실제 데이터가 들어가도록 코드를 리팩터링합니다.

공지사항을 가공하는 로직이 기존에는 주로 adapter 혹은 여기저기 흩어져있었는데
Mapper가 Entity를 Dto로 바꿀때 모두 처리하도록 수정했습니다.
그로 인해 adapter의 수정이 필요해 전면 수정하였습니다.

view 입장에서 usecase만 호출해서 받아온 값을 바로 사용할 수 있도록 하였습니다.