### PR TITLE
refactor: 카카오 공지사항, 학사일정 정상화

### DIFF
--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/AriApi.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/AriApi.kt
@@ -9,5 +9,5 @@ import retrofit2.http.POST
 interface AriApi {
     @FormUrlEncoded
     @POST("indexProc.do")
-    fun getAriNoticeList(@FieldMap fields: MutableMap<String, String>): Response<ResponseBody>
+    suspend fun getAriNoticeList(@FieldMap fields: MutableMap<String, String>): Response<ResponseBody>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/KakaoApi.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/KakaoApi.kt
@@ -6,11 +6,11 @@ import retrofit2.http.GET
 
 interface KakaoApi {
     @GET("_jxehRd")
-    fun getEduNoticeList(): Response<KakaoEntity>
+    suspend fun getEduNoticeList(): Response<KakaoEntity>
 
     @GET("_iMxaFC")
-    fun getJobNoticeList(): Response<KakaoEntity>
+    suspend fun getJobNoticeList(): Response<KakaoEntity>
 
     @GET("_lNmNd")
-    fun getAriPanelNoticeList(): Response<KakaoEntity>
+    suspend fun getAriPanelNoticeList(): Response<KakaoEntity>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/ScheduleApi.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/api/ScheduleApi.kt
@@ -1,12 +1,15 @@
 package com.juhwan.anyang_yi.data.api
 
-import okhttp3.ResponseBody
+import com.juhwan.anyang_yi.data.model.ScheduleEntity
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Headers
+import retrofit2.http.Query
 
 interface ScheduleApi {
-    @Headers("Accept-Language: ko, en-US")
-    @GET("search?q=cache:https://sub.anyang.ac.kr/AYUhub_web/support/collegeInfo/coll0101.asp")
-    fun getScheduleList(): Response<ResponseBody>
+    @GET("academic-schedule.do?")
+    suspend fun getScheduleList(
+        @Query("mode") mode: String,
+        @Query("start") start: String,
+        @Query("end") end: String
+    ): Response<ScheduleEntity>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/di/NetworkModule.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.juhwan.anyang_yi.present.config.Constants
 import com.juhwan.anyang_yi.present.config.Constants.ARI_BASE_URL
 import com.juhwan.anyang_yi.present.config.Constants.KAKAO_BASE_URL
 import com.juhwan.anyang_yi.present.config.Constants.NONSUBJECT_BASE_URL
+import com.juhwan.anyang_yi.present.config.Constants.SCHEDULE_BASE_URL
 import com.juhwan.anyang_yi.present.config.Constants.UNIV_BASE_URL
 import dagger.Module
 import dagger.Provides
@@ -101,7 +102,7 @@ class NetworkModule {
         okHttpClient: OkHttpClient
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(UNIV_BASE_URL)
+            .baseUrl(SCHEDULE_BASE_URL)
             .client(okHttpClient)
             .client(provideHttpClient())
             .addConverterFactory(GsonConverterFactory.create())

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/KakaoMapper.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/KakaoMapper.kt
@@ -7,17 +7,38 @@ import com.juhwan.anyang_yi.present.utils.DateUtil
 object KakaoMapper {
     operator fun invoke(kakaoEntity: KakaoEntity): List<Kakao> {
         var newList = arrayListOf<Kakao>()
+        var size = if(kakaoEntity.posts.items.size > 10) {
+            10
+        } else {
+            kakaoEntity.posts.items.size
+        }
 
-        kakaoEntity.posts.items.forEach { i ->
-            newList.add(
-                Kakao(
-                    isNew = DateUtil.getLeftDay(i.created_at) < 2,
-                    url = i.media[0].small_url,
-                    title = i.title,
-                    date = DateUtil.millisecondToDate(i.created_at),
-                    webLink = i.permalink
+        for ((index, value) in kakaoEntity.posts.items.withIndex()) {
+            if(index == size) {
+                break
+            }
+
+            try {
+                val url = if(value.media == null) {
+                    null
+                } else if(value.media[0].small_url == null) {
+                    value.media[0].medium.small_url
+                } else {
+                    value.media[0].small_url
+                }
+
+                newList.add(
+                    Kakao(
+                        isNew = DateUtil.getLeftDay(value.created_at) < 2,
+                        url = url,
+                        title = value.title,
+                        date = DateUtil.millisecondToDate(value.created_at),
+                        webLink = value.permalink
+                    )
                 )
-            )
+            } catch (e: Exception) {
+
+            }
         }
 
         return newList

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/ScheduleMapper.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/mapper/ScheduleMapper.kt
@@ -1,26 +1,27 @@
 package com.juhwan.anyang_yi.data.mapper
 
+import com.juhwan.anyang_yi.data.model.ScheduleEntity
 import com.juhwan.anyang_yi.domain.model.Schedule
 import okhttp3.ResponseBody
 import org.jsoup.Jsoup
 
 object ScheduleMapper {
-    operator fun invoke(responseBody: ResponseBody): List<Schedule> {
+    operator fun invoke(scheduleEntity: ScheduleEntity): List<Schedule> {
         var list = ArrayList<Schedule>()
 
-        var doc = Jsoup.parse(responseBody.toString())
-        var elementDate = doc.select(".calListTableDate")
-        var elementContent = doc.select(".calListTableCon")
-
-        for (i in 0 until elementContent.size) {
-            if (elementDate[i].text().isEmpty()) { // 내용이 길어 2줄로 이어지는 경우
-                var dateBackup = list[list.lastIndex].date
-                var contentBackup = list[list.lastIndex].content
-                list.removeAt(list.lastIndex)
-                list.add(Schedule(dateBackup, contentBackup + elementContent[i].text()))
-            } else {
-                list.add(Schedule(elementDate[i].text(), elementContent[i].text()))
-            }
+        scheduleEntity.items.forEach {
+            list.add(
+                Schedule (
+                    startYear = it.startDate.substring(0, 4),
+                    startMonth = it.startDate.substring(5, 7),
+                    startDay = it.startDate.substring(8, 10),
+                    endYear = it.endDate.substring(0, 4),
+                    endMonth = it.endDate.substring(5, 7),
+                    endDay = it.endDate.substring(8, 10),
+                    period = it.startDate.substring(5, it.startDate.length) + "~" + it.endDate.substring(5, it.endDate.length),
+                    content = it.title
+                )
+            )
         }
 
         return list

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/model/KakaoEntity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/model/KakaoEntity.kt
@@ -4,7 +4,7 @@ data class KakaoEntity(
     val posts: Posts
 )
 
-data class Posts (
+data class Posts(
     val items: ArrayList<Item>
 )
 
@@ -16,5 +16,10 @@ data class Item(
 )
 
 data class Media(
+    val medium: Medium,
+    val small_url: String
+)
+
+data class Medium(
     val small_url: String
 )

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/model/ScheduleEntity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/model/ScheduleEntity.kt
@@ -1,0 +1,11 @@
+package com.juhwan.anyang_yi.data.model
+
+data class ScheduleEntity(
+    val items: ArrayList<Items>
+)
+
+data class Items(
+    val startDate: String,
+    val endDate: String,
+    val title: String
+)

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/AriRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/AriRepositoryImpl.kt
@@ -14,7 +14,7 @@ class AriRepositoryImpl @Inject constructor(
     private val ariRemoteDataSource: AriRemoteDataSource
 ) : AriRepository {
 
-    override fun getAriNoticeList(page: Int): Result<List<Ari>> {
+    override suspend fun getAriNoticeList(page: Int): Result<List<Ari>> {
         val field: MutableMap<String, String> = HashMap()
         field["schWord"] = "empty"
         field["noneChk"] = "2"
@@ -36,14 +36,14 @@ class AriRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getRecentAriNoticeList(): Result<List<Ari>> {
+    override suspend fun getRecentAriNoticeList(): Result<List<Ari>> {
         val result = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
             getAriNoticeList(1)
         }
 
         return result.apply {
             if(this.data != null && this.data!!.size > 5) {
-                this.data!!.subList(0, 5)
+                this.data = this.data!!.subList(0, 5)
             }
         }
     }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/KakaoRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/KakaoRepositoryImpl.kt
@@ -5,15 +5,20 @@ import com.juhwan.anyang_yi.data.repository.kakao.KakaoRemoteDataSource
 import com.juhwan.anyang_yi.domain.model.Kakao
 import com.juhwan.anyang_yi.domain.repository.KakaoRepository
 import com.juhwan.anyang_yi.present.utils.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class KakaoRepositoryImpl @Inject constructor(
     private val kakaoRemoteDataSource: KakaoRemoteDataSource
 ) : KakaoRepository {
 
-    override fun getEduNoticeList(): Result<List<Kakao>> {
+    override suspend fun getEduNoticeList(): Result<List<Kakao>> {
         return try {
-            val response = kakaoRemoteDataSource.getEduNoticeList()
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                kakaoRemoteDataSource.getEduNoticeList()
+            }
 
             if (response.isSuccessful && response.body() != null) {
                 Result.success(KakaoMapper(response.body()!!))
@@ -25,9 +30,11 @@ class KakaoRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getJobNoticeList(): Result<List<Kakao>> {
+    override suspend fun getJobNoticeList(): Result<List<Kakao>> {
         return try {
-            val response = kakaoRemoteDataSource.getJobNoticeList()
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                kakaoRemoteDataSource.getJobNoticeList()
+            }
 
             if (response.isSuccessful && response.body() != null) {
                 Result.success(KakaoMapper(response.body()!!))
@@ -39,9 +46,11 @@ class KakaoRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getAriPanelNoticeList(): Result<List<Kakao>> {
+    override suspend fun getAriPanelNoticeList(): Result<List<Kakao>> {
         return try {
-            val response = kakaoRemoteDataSource.getAriPanelNoticeList()
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                kakaoRemoteDataSource.getAriPanelNoticeList()
+            }
 
             if (response.isSuccessful && response.body() != null) {
                 Result.success(KakaoMapper(response.body()!!))

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ScheduleRepositoryImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ScheduleRepositoryImpl.kt
@@ -1,19 +1,25 @@
 package com.juhwan.anyang_yi.data.repository
 
+import android.util.Log
 import com.juhwan.anyang_yi.data.mapper.ScheduleMapper
 import com.juhwan.anyang_yi.data.repository.schedule.ScheduleRemoteDataSource
 import com.juhwan.anyang_yi.domain.model.Schedule
 import com.juhwan.anyang_yi.domain.repository.ScheduleRepository
 import com.juhwan.anyang_yi.present.utils.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ScheduleRepositoryImpl @Inject constructor(
     private val scheduleRemoteDataSource: ScheduleRemoteDataSource
 ) : ScheduleRepository {
 
-    override fun getScheduleList(): Result<List<Schedule>> {
+    override suspend fun getScheduleList(start: String, end: String): Result<List<Schedule>> {
         return try {
-            val response = scheduleRemoteDataSource.getScheduleList()
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                scheduleRemoteDataSource.getScheduleList("getCalendarData", start, end)
+            }
 
             if(response.isSuccessful && response.body() != null) {
                 Result.success(ScheduleMapper(response.body()!!))

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ari/AriRemoteDataSource.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ari/AriRemoteDataSource.kt
@@ -4,5 +4,5 @@ import okhttp3.ResponseBody
 import retrofit2.Response
 
 interface AriRemoteDataSource {
-    fun getAriNoticeList(fields: MutableMap<String, String>): Response<ResponseBody>
+    suspend fun getAriNoticeList(fields: MutableMap<String, String>): Response<ResponseBody>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ari/AriRemoteDataSourceImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/ari/AriRemoteDataSourceImpl.kt
@@ -9,7 +9,7 @@ class AriRemoteDataSourceImpl @Inject constructor(
     private val ariApi: AriApi
 ) : AriRemoteDataSource {
 
-    override fun getAriNoticeList(fields: MutableMap<String, String>): Response<ResponseBody> {
+    override suspend fun getAriNoticeList(fields: MutableMap<String, String>): Response<ResponseBody> {
         return ariApi.getAriNoticeList(fields)
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/kakao/KakaoRemoteDataSource.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/kakao/KakaoRemoteDataSource.kt
@@ -5,7 +5,7 @@ import retrofit2.Response
 import retrofit2.http.GET
 
 interface KakaoRemoteDataSource {
-    fun getEduNoticeList(): Response<KakaoEntity>
-    fun getJobNoticeList(): Response<KakaoEntity>
-    fun getAriPanelNoticeList(): Response<KakaoEntity>
+    suspend fun getEduNoticeList(): Response<KakaoEntity>
+    suspend fun getJobNoticeList(): Response<KakaoEntity>
+    suspend fun getAriPanelNoticeList(): Response<KakaoEntity>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/kakao/KakaoRemoteDataSourceImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/kakao/KakaoRemoteDataSourceImpl.kt
@@ -8,15 +8,15 @@ import javax.inject.Inject
 class KakaoRemoteDataSourceImpl @Inject constructor(
     private val kakaoApi: KakaoApi
 ) : KakaoRemoteDataSource {
-    override fun getEduNoticeList(): Response<KakaoEntity> {
+    override suspend fun getEduNoticeList(): Response<KakaoEntity> {
         return kakaoApi.getEduNoticeList()
     }
 
-    override fun getJobNoticeList(): Response<KakaoEntity> {
+    override suspend fun getJobNoticeList(): Response<KakaoEntity> {
         return kakaoApi.getJobNoticeList()
     }
 
-    override fun getAriPanelNoticeList(): Response<KakaoEntity> {
+    override suspend fun getAriPanelNoticeList(): Response<KakaoEntity> {
         return kakaoApi.getAriPanelNoticeList()
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/schedule/ScheduleRemoteDataSource.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/schedule/ScheduleRemoteDataSource.kt
@@ -1,8 +1,8 @@
 package com.juhwan.anyang_yi.data.repository.schedule
 
-import okhttp3.ResponseBody
+import com.juhwan.anyang_yi.data.model.ScheduleEntity
 import retrofit2.Response
 
 interface ScheduleRemoteDataSource {
-    fun getScheduleList(): Response<ResponseBody>
+    suspend fun getScheduleList(mode: String, start: String, end: String): Response<ScheduleEntity>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/schedule/ScheduleRemoteDataSourceImpl.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/data/repository/schedule/ScheduleRemoteDataSourceImpl.kt
@@ -1,8 +1,7 @@
 package com.juhwan.anyang_yi.data.repository.schedule
 
 import com.juhwan.anyang_yi.data.api.ScheduleApi
-import io.reactivex.Single
-import okhttp3.ResponseBody
+import com.juhwan.anyang_yi.data.model.ScheduleEntity
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -10,7 +9,7 @@ class ScheduleRemoteDataSourceImpl @Inject constructor(
     private val scheduleApi: ScheduleApi
 ) : ScheduleRemoteDataSource {
 
-    override fun getScheduleList(): Response<ResponseBody> {
-        return scheduleApi.getScheduleList()
+    override suspend fun getScheduleList(mode: String, start: String, end: String): Response<ScheduleEntity> {
+        return scheduleApi.getScheduleList(mode, start, end)
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Kakao.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Kakao.kt
@@ -2,7 +2,7 @@ package com.juhwan.anyang_yi.domain.model
 
 data class Kakao(
     val isNew: Boolean,
-    val url: String,
+    val url: String?,
     val title: String,
     val date: String,
     val webLink: String

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Schedule.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/model/Schedule.kt
@@ -1,6 +1,12 @@
 package com.juhwan.anyang_yi.domain.model
 
 data class Schedule (
-    var date: String,
+    var startYear: String,
+    var startMonth: String,
+    var startDay: String,
+    var endYear: String,
+    var endMonth: String,
+    var endDay: String,
+    var period: String,
     var content: String
 )

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/AriRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/AriRepository.kt
@@ -4,6 +4,6 @@ import com.juhwan.anyang_yi.domain.model.Ari
 import com.juhwan.anyang_yi.present.utils.Result
 
 interface AriRepository {
-    fun getAriNoticeList(page: Int): Result<List<Ari>>
-    fun getRecentAriNoticeList(): Result<List<Ari>>
+    suspend fun getAriNoticeList(page: Int): Result<List<Ari>>
+    suspend fun getRecentAriNoticeList(): Result<List<Ari>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/KakaoRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/KakaoRepository.kt
@@ -4,7 +4,7 @@ import com.juhwan.anyang_yi.domain.model.Kakao
 import com.juhwan.anyang_yi.present.utils.Result
 
 interface KakaoRepository {
-    fun getEduNoticeList(): Result<List<Kakao>>
-    fun getJobNoticeList(): Result<List<Kakao>>
-    fun getAriPanelNoticeList(): Result<List<Kakao>>
+    suspend fun getEduNoticeList(): Result<List<Kakao>>
+    suspend fun getJobNoticeList(): Result<List<Kakao>>
+    suspend fun getAriPanelNoticeList(): Result<List<Kakao>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/ScheduleRepository.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/repository/ScheduleRepository.kt
@@ -4,5 +4,5 @@ import com.juhwan.anyang_yi.domain.model.Schedule
 import com.juhwan.anyang_yi.present.utils.Result
 
 interface ScheduleRepository {
-    fun getScheduleList(): Result<List<Schedule>>
+    suspend fun getScheduleList(start: String, end: String): Result<List<Schedule>>
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetAriListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetAriListUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetAriListUseCase @Inject constructor(
     private val ariRepository: AriRepository
 ) {
-    operator fun invoke(page: Int): Result<List<Ari>> = ariRepository.getAriNoticeList(page)
+    suspend operator fun invoke(page: Int): Result<List<Ari>> = ariRepository.getAriNoticeList(page)
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetRecentAriListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/ari/GetRecentAriListUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetRecentAriListUseCase @Inject constructor(
     private val ariRepository: AriRepository
 ) {
-    operator fun invoke(): Result<List<Ari>> = ariRepository.getRecentAriNoticeList()
+    suspend operator fun invoke(): Result<List<Ari>> = ariRepository.getRecentAriNoticeList()
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/kakao/GetKakaoListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/kakao/GetKakaoListUseCase.kt
@@ -1,7 +1,6 @@
 package com.juhwan.anyang_yi.domain.usecase.kakao
 
 import com.juhwan.anyang_yi.domain.model.Kakao
-import com.juhwan.anyang_yi.domain.model.Univ
 import com.juhwan.anyang_yi.domain.repository.KakaoRepository
 import com.juhwan.anyang_yi.present.utils.Result
 import javax.inject.Inject
@@ -9,7 +8,7 @@ import javax.inject.Inject
 class GetKakaoListUseCase @Inject constructor(
     private val kakaoRepository: KakaoRepository
 ) {
-    fun getEduNoticeList(): Result<List<Kakao>> = kakaoRepository.getEduNoticeList()
-    fun getJobNoticeList(): Result<List<Kakao>> = kakaoRepository.getJobNoticeList()
-    fun getAriPanelNoticeList(): Result<List<Kakao>> = kakaoRepository.getAriPanelNoticeList()
+    suspend fun getEduNoticeList(): Result<List<Kakao>> = kakaoRepository.getEduNoticeList()
+    suspend fun getJobNoticeList(): Result<List<Kakao>> = kakaoRepository.getJobNoticeList()
+    suspend fun getAriPanelNoticeList(): Result<List<Kakao>> = kakaoRepository.getAriPanelNoticeList()
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/schedule/GetScheduleListUseCase.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/domain/usecase/schedule/GetScheduleListUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetScheduleListUseCase @Inject constructor(
     private val scheduleRepository: ScheduleRepository
 ) {
-    operator fun invoke(): Result<List<Schedule>> = scheduleRepository.getScheduleList()
+    suspend operator fun invoke(start: String, end: String): Result<List<Schedule>> = scheduleRepository.getScheduleList(start, end)
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/config/Constants.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/config/Constants.kt
@@ -6,7 +6,7 @@ object Constants {
     const val KAKAO_BASE_URL = "https://pf-wapi.kakao.com/web/profiles/"
     const val NONSUBJECT_BASE_URL = "https://ari.anyang.ac.kr/user/subject/nsubject/"
     const val NONSUBJECT_IMAGE_BASE_URL = "http://ari.anyang.ac.kr"
-    const val SCHEDULE_BASE_URL = "https://webcache.googleusercontent.com/"
+    const val SCHEDULE_BASE_URL = "https://www.anyang.ac.kr/main/academic/"
     const val UNIV_BASE_URL = "https://www.anyang.ac.kr/main/communication/"
     const val UNIV_WEB_LINK_BASE_URL = "https://www.anyang.ac.kr/main/communication/notice.do"
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/utils/DateUtil.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/utils/DateUtil.kt
@@ -21,4 +21,12 @@ object DateUtil {
 
         return calculateDate.toInt()
     }
+
+    fun getFirstDayOfThisYear(): String {
+        return "${LocalDate.now().year}-01-01"
+    }
+
+    fun getLastDayOfThisYear(): String {
+        return "${LocalDate.now().year}-12-31"
+    }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/contact/ContactFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/contact/ContactFragment.kt
@@ -1,11 +1,9 @@
 package com.juhwan.anyang_yi.present.views.contact
 
-import android.Manifest
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.FragmentContactBinding

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/KakaoAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/KakaoAdapter.kt
@@ -33,6 +33,7 @@ class KakaoAdapter : RecyclerView.Adapter<KakaoAdapter.KakaoViewHolder>() {
     fun setList(list: List<Kakao>) {
         items.clear()
         items.addAll(list)
+        notifyDataSetChanged()
     }
 
     inner class KakaoViewHolder(private val binding: ItemKakaoBinding) :

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/SocialFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/social/SocialFragment.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.FragmentSocialBinding
@@ -68,7 +67,6 @@ class SocialFragment : BaseFragment<FragmentSocialBinding>(R.layout.fragment_soc
         }
 
         binding!!.tvSeeAllEdu.setOnClickListener {
-            //startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://plus.kakao.com/home/@jxehRd")))
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://pf.kakao.com/_jxehRd")))
         }
         binding!!.tvSeeAllJob.setOnClickListener {

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleAdapter.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleAdapter.kt
@@ -23,10 +23,15 @@ class ScheduleAdapter : RecyclerView.Adapter<ScheduleAdapter.ScheduleViewHolder>
         holder.bind(items[position])
     }
 
+    fun setList(list: List<Schedule>) {
+        items.clear()
+        items.addAll(list)
+    }
+
     inner class ScheduleViewHolder(private val binding: ItemScheduleBinding):RecyclerView.ViewHolder(binding.root){
         fun bind(schedule: Schedule) {
             binding.tvScheduleTitle.text = schedule.content
-            binding.tvScheduleDate.text = schedule.date
+            binding.tvScheduleDate.text = schedule.period
         }
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleFragment.kt
@@ -2,16 +2,21 @@ package com.juhwan.anyang_yi.present.views.schedule
 
 import android.os.Bundle
 import android.view.View
-import androidx.lifecycle.Observer
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.juhwan.anyang_yi.R
 import com.juhwan.anyang_yi.databinding.FragmentScheduleBinding
 import com.juhwan.anyang_yi.domain.model.Schedule
 import com.juhwan.anyang_yi.present.config.BaseFragment
+import com.juhwan.anyang_yi.present.utils.DateUtil
+import dagger.hilt.android.AndroidEntryPoint
 import xyz.sangcomz.stickytimelineview.callback.SectionCallback
 import xyz.sangcomz.stickytimelineview.model.SectionInfo
 
+@AndroidEntryPoint
 class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment_schedule) {
+    private val viewModel: ScheduleViewModel by viewModels()
+    private lateinit var scheduleAdapter: ScheduleAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -26,27 +31,37 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding>(R.layout.fragment
 //            binding!!.lottieSheep.visibility = View.GONE
 //            initRecyclerView()
 //        })
+        viewModel.getScheduleList(DateUtil.getFirstDayOfThisYear(), DateUtil.getLastDayOfThisYear())
+        initView()
+        initEvent()
     }
 
-    private fun initRecyclerView() {
+    private fun initView() {
         binding!!.rvTimeline.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
-        binding!!.rvTimeline.addItemDecoration(getSectionCallback())
-        binding!!.rvTimeline.adapter = ScheduleAdapter()
+        scheduleAdapter = ScheduleAdapter()
+        binding!!.rvTimeline.adapter = scheduleAdapter
     }
 
-    private fun getSectionCallback(): SectionCallback {
-        //var items = ScheduleRepository_.schedule
-        var items = ArrayList<Schedule>()
+    private fun initEvent() {
+        viewModel.scheduleList.observe(viewLifecycleOwner) {
+            scheduleAdapter.setList(it)
+            binding!!.rvTimeline.addItemDecoration(getSectionCallback(it))
+        }
 
+        viewModel.problem.observe(viewLifecycleOwner) {
+            showToastMessage(resources.getString(R.string.network_error))
+        }
+    }
+
+    private fun getSectionCallback(items: List<Schedule>): SectionCallback {
         return object : SectionCallback {
             //In your data, implement a method to determine if this is a section.
             override fun isSection(position: Int): Boolean =
-                items[position].date.substring(0, 2) != items[position - 1].date.substring(0, 2)
+                items[position].startMonth != items[position - 1].startMonth
 
             //Implement a method that returns a SectionHeader.
             override fun getSectionHeader(position: Int): SectionInfo? {
-                val schedule = items[position]
-                return SectionInfo("2021." + schedule.date.substring(0, 2), "학사일정")
+                return SectionInfo("2022." + items[position].startMonth, "학사일정")
             }
         }
     }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleViewModel.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/schedule/ScheduleViewModel.kt
@@ -1,7 +1,35 @@
 package com.juhwan.anyang_yi.present.views.schedule
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.juhwan.anyang_yi.domain.model.Schedule
+import com.juhwan.anyang_yi.domain.usecase.schedule.GetScheduleListUseCase
+import com.juhwan.anyang_yi.present.utils.Result
+import com.juhwan.anyang_yi.present.utils.Status
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class ScheduleViewModel: ViewModel() {
+@HiltViewModel
+class ScheduleViewModel @Inject constructor(
+    private val getScheduleListUseCase: GetScheduleListUseCase
+): ViewModel() {
+    private val _scheduleList = MutableLiveData<List<Schedule>>()
+    val scheduleList: LiveData<List<Schedule>> get() = _scheduleList
 
+    private val _problem = MutableLiveData<Result<Any>>()
+    val problem: LiveData<Result<Any>> get() = _problem
+
+    fun getScheduleList(start: String, end: String) {
+        viewModelScope.launch {
+            val result = getScheduleListUseCase(start, end)
+            if(result.status == Status.SUCCESS) {
+                result.data.let { _scheduleList.postValue(it) }
+            } else {
+                _problem.postValue(result)
+            }
+        }
+    }
 }


### PR DESCRIPTION
카카오 공지사항과 학사일정을
새로운 프로젝트 구조에서도 정상적으로 작동하도록 수정했습니다.