### PR TITLE
feat: 비교과 공지사항에 shimmer 적용

### DIFF
--- a/PushNotification/app/build.gradle
+++ b/PushNotification/app/build.gradle
@@ -104,4 +104,7 @@ dependencies {
 
     // Paging
     implementation "androidx.paging:paging-runtime:$paging_version"
+
+    // shimmer
+    implementation "com.facebook.shimmer:shimmer:$shimmer_version"
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/config/BaseFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/config/BaseFragment.kt
@@ -11,20 +11,21 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 
 abstract class BaseFragment <B : ViewDataBinding>(@LayoutRes private val layoutResId: Int) : Fragment() {
-    var binding: B? = null
+    private var _binding: B? = null
+    val binding: B get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
-        return binding!!.root
+        _binding  = DataBindingUtil.inflate(inflater, layoutResId, container, false)
+        return _binding!!.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding!!.lifecycleOwner = viewLifecycleOwner
+        _binding?.lifecycleOwner = viewLifecycleOwner
     }
 
     // 토스트 메시지
@@ -34,6 +35,6 @@ abstract class BaseFragment <B : ViewDataBinding>(@LayoutRes private val layoutR
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeFragment.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/NoticeFragment.kt
@@ -23,25 +23,27 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initView()
         viewModel.getRecentAriNoticeList()
         viewModel.getRecentNonsubjectNoticeList()
         viewModel.getRecentUnivNoticeList()
-        initView()
         initEvent()
     }
 
     private fun initView(){
-        binding!!.rvAri.layoutManager = LinearLayoutManager(context)
+        binding.sflNonsubject.visibility = View.VISIBLE
+
+        binding.rvAri.layoutManager = LinearLayoutManager(context)
         recentAriAdapter = RecentAriAdapter()
-        binding!!.rvAri.adapter = recentAriAdapter
+        binding.rvAri.adapter = recentAriAdapter
 
-        binding!!.rvNonsubject.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        binding.rvNonsubject.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
         recentNonsubjectAdapter = RecentNonsubjectAdapter()
-        binding!!.rvNonsubject.adapter = recentNonsubjectAdapter
+        binding.rvNonsubject.adapter = recentNonsubjectAdapter
 
-        binding!!.rvUniv.layoutManager = LinearLayoutManager(context)
+        binding.rvUniv.layoutManager = LinearLayoutManager(context)
         recentUnivAdapter = RecentUnivAdapter()
-        binding!!.rvUniv.adapter = recentUnivAdapter
+        binding.rvUniv.adapter = recentUnivAdapter
     }
 
     private fun initEvent() {
@@ -51,6 +53,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
 
         viewModel.recentNonsubjectNoticeList.observe(viewLifecycleOwner) {
             recentNonsubjectAdapter.setList(it)
+            binding.sflNonsubject.visibility = View.GONE
         }
 
         viewModel.recentUnivNoticeList.observe(viewLifecycleOwner) {
@@ -61,15 +64,15 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding>(R.layout.fragment_not
             showToastMessage(resources.getString(R.string.network_error))
         }
 
-        binding!!.tvSeeAllNonsubject.setOnClickListener {
+        binding.tvSeeAllNonsubject.setOnClickListener {
             startActivity(Intent(context, NonsubjectActivity::class.java))
         }
 
-        binding!!.tvSeeAllUniv.setOnClickListener {
+        binding.tvSeeAllUniv.setOnClickListener {
             startActivity(Intent(context, UnivActivity::class.java))
         }
 
-        binding!!.tvSeeAllAri.setOnClickListener {
+        binding.tvSeeAllAri.setOnClickListener {
             startActivity(Intent(context, AriActivity::class.java))
         }
     }

--- a/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectActivity.kt
+++ b/PushNotification/app/src/main/java/com/juhwan/anyang_yi/present/views/home/notice/nonsubject/NonsubjectActivity.kt
@@ -1,6 +1,7 @@
 package com.juhwan.anyang_yi.present.views.home.notice.nonsubject
 
 import android.os.Bundle
+import android.view.View
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import com.juhwan.anyang_yi.R
@@ -24,6 +25,7 @@ class NonsubjectActivity : BaseActivity<ActivityNonsubjectBinding>(R.layout.acti
     }
 
     private fun initView(){
+        binding.sflNonsubject.visibility = View.VISIBLE
         binding.rvNonsubject.layoutManager = GridLayoutManager(this, 2)
         nonsubjectAdapter = NonsubjectAdapter()
         binding.rvNonsubject.adapter = nonsubjectAdapter
@@ -40,6 +42,7 @@ class NonsubjectActivity : BaseActivity<ActivityNonsubjectBinding>(R.layout.acti
         viewModel.nonsubjectNoticeList.observe(this) {
             nonsubjectAdapter.setList(it)
             binding.totalCnt = it.size
+            binding.sflNonsubject.visibility = View.GONE
         }
 
         viewModel.problem.observe(this) {

--- a/PushNotification/app/src/main/res/layout/activity_nonsubject.xml
+++ b/PushNotification/app/src/main/res/layout/activity_nonsubject.xml
@@ -153,6 +153,44 @@
                         android:layout_marginTop="@dimen/activity_margin_20"
                         app:layout_constraintTop_toBottomOf="@id/tv_total" />
 
+                    <com.facebook.shimmer.ShimmerFrameLayout
+                        android:id="@+id/sfl_nonsubject"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/activity_margin_20"
+                        app:layout_constraintTop_toBottomOf="@id/tv_total">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical">
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="center">
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                            </LinearLayout>
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="center">
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                            </LinearLayout>
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="center">
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                                <include layout="@layout/item_shimmer_nonsubject"/>
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.facebook.shimmer.ShimmerFrameLayout>
+
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>

--- a/PushNotification/app/src/main/res/layout/fragment_notice.xml
+++ b/PushNotification/app/src/main/res/layout/fragment_notice.xml
@@ -52,6 +52,25 @@
                         android:layout_marginTop="@dimen/activity_margin_default"
                         app:layout_constraintTop_toBottomOf="@+id/tv_nonsubject"/>
 
+                    <com.facebook.shimmer.ShimmerFrameLayout
+                        android:id="@+id/sfl_nonsubject"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/activity_margin_default"
+                        android:visibility="gone"
+                        app:layout_constraintTop_toBottomOf="@+id/tv_nonsubject">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <include layout="@layout/item_shimmer_nonsubject"/>
+                            <include layout="@layout/item_shimmer_nonsubject"/>
+                            <include layout="@layout/item_shimmer_nonsubject"/>
+                        </LinearLayout>
+                    </com.facebook.shimmer.ShimmerFrameLayout>
+
                     <View
                         android:id="@+id/divide_1"
                         android:layout_width="match_parent"

--- a/PushNotification/app/src/main/res/layout/item_shimmer_nonsubject.xml
+++ b/PushNotification/app/src/main/res/layout/item_shimmer_nonsubject.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_nonsubject"
+        android:background="@color/clickable_background"
+        android:layout_width="170dp"
+        android:layout_marginLeft="8dp"
+        android:layout_height="210dp">
+
+        <ImageView
+            android:id="@+id/iv_thumbnail"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:layout_marginLeft="2dp"
+            android:background="@color/gray_shimmer"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_title"
+            android:layout_height="@dimen/activity_margin_24"
+            android:layout_width="150dp"
+            android:layout_marginTop="@dimen/activity_margin_12"
+            android:layout_marginLeft="12dp"
+            android:background="@color/gray_shimmer"
+            app:layout_constraintTop_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintLeft_toLeftOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_left_day"
+            android:layout_width="40dp"
+            android:layout_height="35dp"
+            app:srcCompat="@drawable/d_day"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/tv_left_day" />
+
+        <TextView
+            android:id="@+id/tv_left_day"
+            style="@style/toolBarText"
+            android:includeFontPadding="false"
+            android:textColor="@color/colorWhite"
+            android:textSize="12sp"
+            android:layout_marginTop="3dp"
+            tools:text="D-23"
+            app:layout_constraintEnd_toEndOf="@+id/iv_left_day"
+            app:layout_constraintStart_toStartOf="@+id/iv_left_day"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/PushNotification/app/src/main/res/values/colors.xml
+++ b/PushNotification/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="black_high_emphasis">#D9000000</color>
     <color name="black_medium_emphasis">#99000000</color>
     <color name="black_low_emphasis">#66000000</color>
+    <color name="gray_shimmer">#efefef</color>
 
     <!-- for floating button -->
     <color name="black_semi_transparent">#B2000000</color>

--- a/PushNotification/build.gradle
+++ b/PushNotification/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         google_service="4.3.10"
         fcm="23.0.4"
         paging_version = "3.0.0"
+        shimmer_version="0.5.0"
     }
     dependencies {
         //classpath 'com.android.tools.build:gradle:7.1.2' // 4.6.1


### PR DESCRIPTION
<p>
<img src="https://user-images.githubusercontent.com/76620764/174009195-d4b5f88f-5cfb-404f-b7b6-f02834693d7b.gif" height="600"/>

<img src="https://user-images.githubusercontent.com/76620764/174009201-85643b3f-f652-4d25-a5bb-311aad87395d.gif" height="600"/>
</p>

## 개요
- Resolves #40 
- Shimmer 적용

## 작업사항
- 비교과 공지사항 (최근 공지 보기, 전체 보기) 페이지에 Shimmer를 적용했습니다.

## 기타
- 다른 API에 비해 비교과 API가 몇 배 느려 사용자에게 시각적인 안내가 필요하다고 판단하여 Shimmer를 적용했습니다.